### PR TITLE
Catch fetch errors

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -51,16 +51,20 @@ export default class RelayServerSSR {
         }, 30000);
 
         let payload = null;
-        if (hasSchema) {
-          payload = await graphql({
-            ...graphqlArgs,
-            source: req.getQueryString(),
-            variableValues: req.getVariables(),
-          });
-        } else {
-          payload = await next(r);
+        try {
+          if (hasSchema) {
+            payload = await graphql({
+              ...graphqlArgs,
+              source: req.getQueryString(),
+              variableValues: req.getVariables(),
+            });
+          } else {
+            payload = await next(r);
+          }
+          resolve(payload);
+        } catch (e) {
+          reject(e);
         }
-        resolve(payload);
       });
       this.cache.set(cacheKey, gqlResponse);
 


### PR DESCRIPTION
If the fetch fails (e.g. due to hostname resolution failure), the promise is not rejected until the 30 second timeout.

Wrapping this in a try/catch allows the promise to be rejected instantly.