### PR TITLE
fix(server): clearTimeout before resolve or reject

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -46,7 +46,7 @@ export default class RelayServerSSR {
       const graphqlArgs: SSRGraphQLArgs = isFunction(args) ? await args() : (args: any);
       const hasSchema = graphqlArgs && graphqlArgs.schema;
       const gqlResponse = new Promise(async (resolve, reject) => {
-        setTimeout(() => {
+        const timeout = setTimeout(() => {
           reject(new Error('RelayRequest timeout'));
         }, 30000);
 
@@ -61,8 +61,11 @@ export default class RelayServerSSR {
           } else {
             payload = await next(r);
           }
+
+          clearTimeout(timeout);
           resolve(payload);
         } catch (e) {
+          clearTimeout(timeout);
           reject(e);
         }
       });


### PR DESCRIPTION
When I use `react-relay-network-modern-ssr` in my component, running `jest` will get `This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with '--detectOpenHandles' to troubleshoot this issue.`. The reason cause this problem is that `setTimeout` block the testing. I think we should clear timeout before resolve or reject.