### PR TITLE
Docs: clarify lookup option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,7 @@ const relayClientSSR = new RelayClientSSR(window.__RELAY_BOOTSTRAP_DATA__);
 
 const network = new RelayNetworkLayer([
   relayClientSSR.getMiddleware({
-    // Will preserve cache rather than purge after mount.
-    lookup: false
+    lookup: true // Will preserve cache rather than purge after mount.
   }),
 ]);
 


### PR DESCRIPTION
the comment describes, what happens, when the option is set to true